### PR TITLE
runcat: move windowsdesktop-runtime to suggest

### DIFF
--- a/bucket/runcat.json
+++ b/bucket/runcat.json
@@ -3,7 +3,7 @@
     "description": "A cute running cat animation on your windows taskbar (based on CPU load)",
     "homepage": "https://github.com/Kyome22/RunCat_for_windows",
     "license": "Apache-2.0",
-    "depends": "extras/windowsdesktop-runtime-lts",
+    "suggest": "extras/windowsdesktop-runtime-lts",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Kyome22/RunCat_for_windows/releases/download/2.0/RunCat-x64.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Relates to #8837

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Users may already have installed _.NET 6.0 Desktop Runtime_, or they don't want to use scoop to install the runtime.